### PR TITLE
BBL-156 updates to gran 5/5 ansible-galaxy score based on ansible-lin…

### DIFF
--- a/.chglog/CHANGELOG.tpl.md
+++ b/.chglog/CHANGELOG.tpl.md
@@ -1,0 +1,56 @@
+{{ if .Versions -}}
+<a name="unreleased"></a>
+## [Unreleased]
+
+{{ if .Unreleased.CommitGroups -}}
+{{ range .Unreleased.CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{ range .Versions }}
+<a name="{{ .Tag.Name }}"></a>
+## {{ if .Tag.Previous }}[{{ .Tag.Name }}]{{ else }}{{ .Tag.Name }}{{ end }} - {{ datetime "2006-01-02" .Tag.Date }}
+{{ range .CommitGroups -}}
+### {{ .Title }}
+{{ range .Commits -}}
+- {{ if .Scope }}**{{ .Scope }}:** {{ end }}{{ .Subject }}
+{{ end }}
+{{ end -}}
+
+{{- if .RevertCommits -}}
+### Reverts
+{{ range .RevertCommits -}}
+- {{ .Revert.Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .MergeCommits -}}
+### Pull Requests
+{{ range .MergeCommits -}}
+- {{ .Header }}
+{{ end }}
+{{ end -}}
+
+{{- if .NoteGroups -}}
+{{ range .NoteGroups -}}
+### {{ .Title }}
+{{ range .Notes }}
+{{ .Body }}
+{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end -}}
+
+{{- if .Versions }}
+[Unreleased]: {{ .Info.RepositoryURL }}/compare/{{ $latest := index .Versions 0 }}{{ $latest.Tag.Name }}...HEAD
+{{ range .Versions -}}
+{{ if .Tag.Previous -}}
+[{{ .Tag.Name }}]: {{ $.Info.RepositoryURL }}/compare/{{ .Tag.Previous.Name }}...{{ .Tag.Name }}
+{{ end -}}
+{{ end -}}
+{{ end -}}

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,0 +1,28 @@
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/binbashar/ansible-role-vpn-pritunl-init-values
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/.chglog/config.yml
+++ b/.chglog/config.yml
@@ -1,22 +1,10 @@
+---
 style: github
 template: CHANGELOG.tpl.md
 info:
   title: CHANGELOG
   repository_url: https://github.com/binbashar/ansible-role-vpn-pritunl-init-values
 options:
-  commits:
-    # filters:
-    #   Type:
-    #     - feat
-    #     - fix
-    #     - perf
-    #     - refactor
-  commit_groups:
-    # title_maps:
-    #   feat: Features
-    #   fix: Bug Fixes
-    #   perf: Performance Improvements
-    #   refactor: Code Refactoring
   header:
     pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
     pattern_maps:

--- a/.chglog/config.yml.examples
+++ b/.chglog/config.yml.examples
@@ -1,0 +1,29 @@
+---
+style: github
+template: CHANGELOG.tpl.md
+info:
+  title: CHANGELOG
+  repository_url: https://github.com/binbashar/ansible-role-users
+options:
+  commits:
+    # filters:
+    #   Type:
+    #     - feat
+    #     - fix
+    #     - perf
+    #     - refactor
+  commit_groups:
+    # title_maps:
+    #   feat: Features
+    #   fix: Bug Fixes
+    #   perf: Performance Improvements
+    #   refactor: Code Refactoring
+  header:
+    pattern: "^(\\w*)(?:\\(([\\w\\$\\.\\-\\*\\s]*)\\))?\\:\\s(.*)$"
+    pattern_maps:
+      - Type
+      - Scope
+      - Subject
+  notes:
+    keywords:
+      - BREAKING CHANGE

--- a/Makefile
+++ b/Makefile
@@ -36,6 +36,9 @@ init: ## Install required ansible roles
 		pip install -I molecule[docker]==${PY_MOLECULE_VER};\
 	fi;
 
+test-ansible-lint: ## Ansible lint
+	ansible-lint
+
 test-molecule-galaxy: ## Run playbook tests w/ molecule pulling role from ansible galaxy
 	mkdir -p molecule/default/roles
 	ansible-galaxy install ${ANSIBLE_GALAXY_ROLE_NAME} -p molecule/default/roles -f

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -3,7 +3,7 @@ dependencies: []
 
 galaxy_info:
   author: binbash_inc
-  description: User management for Linux - https://galaxy.ansible.com/binbash_inc/ansible_role_users
+  description: Pritunl VPN post installation init values (user / password) for Linux.
   company: "Binbashar Inc."
   license: "license (BSD, MIT)"
   min_ansible_version: 2.5

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,42 +1,51 @@
 ---
 
-- name: Print out pritunl database setup key
+- name: Register Pritunl database setup key output
   command: "{{ pritunl_openvpn_init_cmd_db_setup_key }}"
   register: cmd_output_1
   ignore_errors: true
+  changed_when: false
 
-- set_fact:
+- name: Save pritunl database setup key output to variable
+  set_fact:
     pritunl_db_key: "{{ cmd_output_1.stdout }}"
 
-- debug:
+- name: Print out Pritunl database setup key variable
+  debug:
     msg:
       - '#================================================#'
       - '# PRITUNL_DB_KEY {{ pritunl_db_key }}'
       - '#================================================#'
 
-- name: Print out pritunl default login user admin information
-  shell: "{{ pritunl_openvpn_init_cmd_default_login_admin_user }}"
+- name: Register Pritunl default login user admin information output
+  command: "{{ pritunl_openvpn_init_cmd_default_login_admin_user }}"
   register: cmd_output_2
   ignore_errors: true
+  changed_when: false
 
-- set_fact:
+- name: Save pritunl default admin user setup key output to variable
+  set_fact:
     pritunl_default_user: "{{ cmd_output_2.stdout }}"
 
-- debug:
+- name: Print out Pritunl default admin user setup key variable
+  debug:
     msg:
       - '#================================================#'
       - '# DEFAULT_USER {{ pritunl_default_user }}'
       - '#================================================#'
 
-- name: Print out pritunl default login pass admin information
-  shell: "{{ pritunl_openvpn_init_cmd_default_login_admin_pass }}"
+- name: Register Pritunl default login pass admin information output
+  command: "{{ pritunl_openvpn_init_cmd_default_login_admin_pass }}"
   register: cmd_output_3
   ignore_errors: true
+  changed_when: false
 
-- set_fact:
+- name: Save pritunl default admin password setup key output to variable
+  set_fact:
     pritunl_default_pass: "{{ cmd_output_3.stdout }}"
 
-- debug:
+- name: Print out Pritunl default admin password setup key variable
+  debug:
     msg:
       - '#================================================#'
       - '# DEFAULT_USER {{ pritunl_default_pass }}'


### PR DESCRIPTION
- @exequielrafaela - BBL-156 updates to grant 5/5 ansible-galaxy score based on ansible-lint results- 0224f41
- @exequielrafaela - BBL-156 adding chglog pre-req for automated release mgmt post stage - 8dcd285
- @exequielrafaela - BBL-156 updating .chglog/config.yml to avoid yml lint warnings/errors - ce583f6

NOTE: PRs needs to be merged ASAP in order to get it's 1st version in Ansible Galaxy (https://galaxy.ansible.com/binbash_inc/ansible_role_vpn_pritunl_init_values) 
```
╭─delivery at delivery-I7567 in ~/Binbash/repos/BB-Leverage/ansible/playbooks/ansible-playbook-vpn-pritunl on master✘✘✘ using ‹› 20-01-02 - 15:09:35
╰─○ make init 
ansible-galaxy install -r requirements.yml --roles-path ./roles/
- downloading role 'ansible_role_users', owned by binbash_inc
- downloading role from https://github.com/binbashar/ansible-role-users/archive/v0.0.10.tar.gz
- extracting binbash_inc.ansible_role_users to /home/delivery/Binbash/repos/BB-Leverage/ansible/playbooks/ansible-playbook-vpn-pritunl/roles/binbash_inc.ansible_role_users
- binbash_inc.ansible_role_users (v0.0.10) was installed successfully
- downloading role 'ansible_role_vpn_pritunl_init_values', owned by binbash_inc
- downloading role from https://github.com/binbashar/ansible-role-vpn-pritunl-init-values/archive/v0.0.1.tar.gz
 [ERROR]: failed to download the file: HTTP Error 404: Not Found
```